### PR TITLE
Added Node Visitation & Decay System

### DIFF
--- a/src/main/java/net/rasanovum/viaromana/CommonConfig.java
+++ b/src/main/java/net/rasanovum/viaromana/CommonConfig.java
@@ -66,6 +66,7 @@ public class CommonConfig extends MidnightConfig {
     @Override
     public void writeChanges() {
         super.writeChanges();
+        net.rasanovum.viaromana.client.ClientConfigCache.updateFromCommonConfig();
         ViaRomana.LOGGER.info("Via Romana config saved. Use /reload to update state");
         //TODO: Update relevant systems using a diff check (or similar)
     }

--- a/src/main/java/net/rasanovum/viaromana/CommonConfig.java
+++ b/src/main/java/net/rasanovum/viaromana/CommonConfig.java
@@ -26,6 +26,8 @@ public class CommonConfig extends MidnightConfig {
     @Entry(category = CHARTING) public static List<String> block_string_blacklist = Lists.newArrayList("diagonalwalls:", "diagonalfences:", "diagonalwindows:");
     @Entry(category = CHARTING) public static List<String> invalid_dimensions = Lists.newArrayList();
     @Entry(category = CHARTING) public static boolean no_gui_charting = false;
+    @Entry(category = CHARTING) public static boolean require_walked_path = true;
+    @Entry(category = CHARTING, min = 0) public static int visited_node_decay_time = 0; // In minutes, 0 = no decay
     @Comment(category = CHARTING) public static Comment charting_footer;
 
     @Entry(category = WARP) public static List<String> invalid_entities = Lists.newArrayList();
@@ -53,6 +55,7 @@ public class CommonConfig extends MidnightConfig {
     @Entry(category = VISUALS, min = 0f, max = 1f) public static float biome_map_opacity = 0.3f;
     @Entry(category = VISUALS, min = 0f, max = 1f) public static float node_vignette_opacity = 1.0f;
     @Entry(category = VISUALS, isColor = true) public static List<String> line_colors = Lists.newArrayList("#ffffff", "#cccccc");
+    @Entry(category = VISUALS, isColor = true) public static String visited_line_color = "#3366ff";
     @Entry(category = VISUALS, min = 0f, max = 1f) public static float line_opacity = 1.0f;
     @Entry(category = VISUALS) public static boolean enable_teleport_particles = true;
     @Entry(category = VISUALS) public static boolean enable_sign_particles = true;

--- a/src/main/java/net/rasanovum/viaromana/ViaRomana.java
+++ b/src/main/java/net/rasanovum/viaromana/ViaRomana.java
@@ -51,6 +51,7 @@ public class ViaRomana {
         DataInit.load();
 
         MidnightConfig.init(MODID, CommonConfig.class);
+        net.rasanovum.viaromana.client.ClientConfigCache.updateFromCommonConfig();
 
         ServerResourcesGenerator generator = new ServerResourcesGenerator(DYNAMIC_PACK);
         generator.register();

--- a/src/main/java/net/rasanovum/viaromana/client/ClientConfigCache.java
+++ b/src/main/java/net/rasanovum/viaromana/client/ClientConfigCache.java
@@ -11,12 +11,16 @@ public class ClientConfigCache {
     public static int nodeDistanceMaximum = CommonConfig.node_distance_maximum;
     public static int nodeUtilityDistance = CommonConfig.node_utility_distance;
     public static int infrastructureCheckRadius = CommonConfig.infrastructure_check_radius;
+    public static boolean requireWalkedPath = CommonConfig.require_walked_path;
+    public static int visitedNodeDecayTime = CommonConfig.visited_node_decay_time;
 
-    public static void updateFromServer(float pathQuality, int nodeMin, int nodeMax, int utilityDist, int infraRadius) {
+    public static void updateFromServer(float pathQuality, int nodeMin, int nodeMax, int utilityDist, int infraRadius, boolean requireWalked, int decayTime) {
         pathQualityThreshold = pathQuality;
         nodeDistanceMinimum = nodeMin;
         nodeDistanceMaximum = nodeMax;
         nodeUtilityDistance = utilityDist;
         infrastructureCheckRadius = infraRadius;
+        requireWalkedPath = requireWalked;
+        visitedNodeDecayTime = decayTime;
     }
 }

--- a/src/main/java/net/rasanovum/viaromana/client/ClientConfigCache.java
+++ b/src/main/java/net/rasanovum/viaromana/client/ClientConfigCache.java
@@ -23,4 +23,14 @@ public class ClientConfigCache {
         requireWalkedPath = requireWalked;
         visitedNodeDecayTime = decayTime;
     }
+
+    public static void updateFromCommonConfig() {
+        pathQualityThreshold = CommonConfig.path_quality_threshold;
+        nodeDistanceMinimum = CommonConfig.node_distance_minimum;
+        nodeDistanceMaximum = CommonConfig.node_distance_maximum;
+        nodeUtilityDistance = CommonConfig.node_utility_distance;
+        infrastructureCheckRadius = CommonConfig.infrastructure_check_radius;
+        requireWalkedPath = CommonConfig.require_walked_path;
+        visitedNodeDecayTime = CommonConfig.visited_node_decay_time;
+    }
 }

--- a/src/main/java/net/rasanovum/viaromana/client/ColorUtil.java
+++ b/src/main/java/net/rasanovum/viaromana/client/ColorUtil.java
@@ -21,4 +21,20 @@ public class ColorUtil {
         
         return (red << 16) | (green << 8) | blue;
     }
+
+    /**
+     * Parses a hexadecimal color string (e.g., "#3366ff" or "3366ff") into an integer.
+     * Defaults to white (0xFFFFFF) if the string is invalid.
+     */
+    public static int parseHex(String hex) {
+        if (hex == null || hex.isEmpty()) return 0xFFFFFF;
+        try {
+            if (hex.startsWith("#")) {
+                hex = hex.substring(1);
+            }
+            return Integer.parseInt(hex, 16);
+        } catch (NumberFormatException e) {
+            return 0xFFFFFF;
+        }
+    }
 }

--- a/src/main/java/net/rasanovum/viaromana/client/gui/TeleportMapScreen.java
+++ b/src/main/java/net/rasanovum/viaromana/client/gui/TeleportMapScreen.java
@@ -14,6 +14,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.player.Player;
 import net.rasanovum.viaromana.CommonConfig;
+import net.rasanovum.viaromana.client.ClientConfigCache;
 import net.rasanovum.viaromana.ViaRomana;
 import net.rasanovum.viaromana.client.FadeManager;
 import net.rasanovum.viaromana.client.HudMessageManager;
@@ -78,6 +79,7 @@ public class TeleportMapScreen extends Screen {
     private static final int DIRECTION_COLOR_RGB = 0xFFFFFF;
     private static int LINE_COLOR_BASE = 0xFFFFFF;
     private static int LINE_COLOR_UNDERGROUND = 0xFFFFFF;
+    private static int LINE_COLOR_VISITED = 0x3366FF;
     private static float LINE_OPACITY = 1.0f;
     //endregion
 
@@ -220,6 +222,7 @@ public class TeleportMapScreen extends Screen {
 
         LINE_COLOR_BASE = Color.decode(CommonConfig.line_colors.get(0)).getRGB();
         LINE_COLOR_UNDERGROUND = Color.decode(CommonConfig.line_colors.get(1)).getRGB();
+        LINE_COLOR_VISITED = Color.decode(CommonConfig.visited_line_color).getRGB();
         LINE_OPACITY = CommonConfig.line_opacity;
 
         updateAnimationProgress();
@@ -292,8 +295,14 @@ public class TeleportMapScreen extends Screen {
         DestinationResponseS2C.NodeNetworkInfo endInfo = networkNodeMap.get(endPos);
         boolean bothUnderground = startInfo.clearance > 0 && startInfo.clearance < 24 &&
                 endInfo != null && endInfo.clearance > 0 && endInfo.clearance < 24;
+        boolean bothVisited = ClientConfigCache.requireWalkedPath && startInfo.visited && (endInfo != null && endInfo.visited);
 
-        int color = bothUnderground ? LINE_COLOR_UNDERGROUND : LINE_COLOR_BASE;
+        int color;
+        if (bothVisited) {
+            color = LINE_COLOR_VISITED;
+        } else {
+            color = bothUnderground ? LINE_COLOR_UNDERGROUND : LINE_COLOR_BASE;
+        }
         color = applyLineAlpha(color);
 
         Optional<Point> endScreenPosOpt = worldToScreen(endPos);

--- a/src/main/java/net/rasanovum/viaromana/client/render/NodeRenderer.java
+++ b/src/main/java/net/rasanovum/viaromana/client/render/NodeRenderer.java
@@ -16,6 +16,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.phys.Vec3;
+import net.rasanovum.viaromana.CommonConfig;
 import net.rasanovum.viaromana.client.ColorUtil;
 import net.rasanovum.viaromana.client.data.ClientPathData;
 import net.rasanovum.viaromana.client.ClientConfigCache;
@@ -113,7 +114,7 @@ public class NodeRenderer {
         Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
         Vec3 playerPos = player.position();
         
-        List<NodeRenderData> nodeDataList = gatherRenderData(clientLevel, playerPos, level.dimension());
+        List<NodeRenderData> nodeDataList = gatherRenderData(clientLevel, player, playerPos, level.dimension());
         
         BlockPos selectedNodePos = findAndSetSelectedNode(player, nodeDataList, level.dimension());
         updateAnimatedAlphas(selectedNodePos);
@@ -163,11 +164,11 @@ public class NodeRenderer {
     }
 
     // Gathers all visible nodes and pre-calculates their expensive data.
-    private static List<NodeRenderData> gatherRenderData(ClientLevel level, Vec3 playerPos, ResourceKey<Level> dimension) {
+    private static List<NodeRenderData> gatherRenderData(ClientLevel level, Player player, Vec3 playerPos, ResourceKey<Level> dimension) {
         List<NodeRenderData> dataList = new ArrayList<>();
         double searchRadius = RENDER_DISTANCE + FADE_BUFFER_DISTANCE;
 
-        if (PlayerData.isChartingPath(Minecraft.getInstance().player)) {
+        if (PlayerData.isChartingPath(player)) {
             ClientPathData.getInstance().getTemporaryNodes().stream()
                 .map(nodeData -> {
                     double adjY = RenderUtil.findSuitableYPosition(level, nodeData.pos(), 0.25f);
@@ -180,12 +181,21 @@ public class NodeRenderer {
 
         PathGraph graph = ClientPathData.getInstance().getGraph(dimension);
         if (graph != null) {
+            UUID playerId = player.getUUID();
+            int visitedColor = ColorUtil.parseHex(CommonConfig.visited_line_color);
+
             ClientPathData.getInstance().getNearbyNodes(BlockPos.containing(playerPos), searchRadius, false, dimension).stream()
                 .map(node -> {
                     BlockPos pos = BlockPos.of(node.getPos());
                     double adjY = RenderUtil.findSuitableYPosition(level, pos, 0.25f);
                     double dist = calculateDistanceToNodeBeamInternal(playerPos, pos, adjY);
-                    return new NodeRenderData(pos, dist, adjY, DEFAULT_BEAM_COLOR);
+
+                    int color = DEFAULT_BEAM_COLOR;
+                    if (ClientConfigCache.requireWalkedPath && node.hasVisited(playerId)) {
+                        color = visitedColor;
+                    }
+
+                    return new NodeRenderData(pos, dist, adjY, color);
                 })
                 .filter(data -> data.distance <= searchRadius)
                 .forEach(dataList::add);

--- a/src/main/java/net/rasanovum/viaromana/items/ChartingMap.java
+++ b/src/main/java/net/rasanovum/viaromana/items/ChartingMap.java
@@ -55,7 +55,7 @@ public class ChartingMap extends Item {
                     PathGraph.NetworkCache networkCache = graph.getNetworkCacheForNode(node);
 
                     List<net.rasanovum.viaromana.path.Node> destinations = graph.getCachedTeleportDestinationsFor(serverPlayer.getUUID(), node);
-                    List<DestinationResponseS2C.NodeNetworkInfo> networkInfos = graph.getNodesAsInfo(networkCache);
+                    List<DestinationResponseS2C.NodeNetworkInfo> networkInfos = graph.getNodesAsInfo(serverPlayer.getUUID(), networkCache);
 
                     DestinationResponseS2C responsePacket = new DestinationResponseS2C(
                             graph.getNodesAsDestinationInfo(destinations, node.getBlockPos()),

--- a/src/main/java/net/rasanovum/viaromana/map/MapInfo.java
+++ b/src/main/java/net/rasanovum/viaromana/map/MapInfo.java
@@ -63,12 +63,7 @@ public record MapInfo(
 
         buffer.writeInt(networkNodes.size());
         for (NodeNetworkInfo node : networkNodes) {
-            buffer.writeBlockPos(node.position);
-            buffer.writeFloat(node.clearance);
-            buffer.writeInt(node.connections.size());
-            for (BlockPos connection : node.connections) {
-                buffer.writeBlockPos(connection);
-            }
+            node.write(buffer);
         }
 
         if (hasImageData()) {
@@ -109,14 +104,7 @@ public record MapInfo(
         int nodeCount = buffer.readInt();
         List<NodeNetworkInfo> networkNodes = new ArrayList<>(nodeCount);
         for (int i = 0; i < nodeCount; i++) {
-            BlockPos nodePos = buffer.readBlockPos();
-            float clearance = buffer.readFloat();
-            int connectionCount = buffer.readInt();
-            List<BlockPos> connections = new ArrayList<>(connectionCount);
-            for (int j = 0; j < connectionCount; j++) {
-                connections.add(buffer.readBlockPos());
-            }
-            networkNodes.add(new NodeNetworkInfo(nodePos, clearance, connections));
+            networkNodes.add(new NodeNetworkInfo(buffer));
         }
 
         // Read raw pixel data and world coordinates

--- a/src/main/java/net/rasanovum/viaromana/network/PacketRegistration.java
+++ b/src/main/java/net/rasanovum/viaromana/network/PacketRegistration.java
@@ -33,5 +33,6 @@ public class PacketRegistration {
         PacketRegistrar.register(S2C_CONTAINER, "teleport_fade_s2c", TeleportFadeS2C.class, TeleportFadeS2C::write, TeleportFadeS2C::new, TeleportFadeS2C::handle);
         PacketRegistrar.register(S2C_CONTAINER, "sign_validation_response_s2c", SignValidationResponseS2C.class, SignValidationResponseS2C::write, SignValidationResponseS2C::new, SignValidationResponseS2C::handle);
         PacketRegistrar.register(S2C_CONTAINER, "destination_response_s2c", DestinationResponseS2C.class, DestinationResponseS2C::write, DestinationResponseS2C::new, DestinationResponseS2C::handle);
+        PacketRegistrar.register(S2C_CONTAINER, "node_visited_s2c", NodeVisitedS2C.class, NodeVisitedS2C::write, NodeVisitedS2C::new, NodeVisitedS2C::handle);
     }
 }

--- a/src/main/java/net/rasanovum/viaromana/network/packets/ChartedPathC2S.java
+++ b/src/main/java/net/rasanovum/viaromana/network/packets/ChartedPathC2S.java
@@ -19,6 +19,7 @@ import net.rasanovum.viaromana.ViaRomana;
 import net.rasanovum.viaromana.init.StatInit;
 import net.rasanovum.viaromana.map.ServerMapCache;
 import net.rasanovum.viaromana.network.AbstractPacket;
+import net.rasanovum.viaromana.path.Node;
 import net.rasanovum.viaromana.path.Node.NodeData;
 import net.rasanovum.viaromana.path.PathGraph;
 import net.rasanovum.viaromana.storage.path.PathDataManager;
@@ -85,7 +86,11 @@ public record ChartedPathC2S(List<NodeData> chartedNodes) implements AbstractPac
 
                 serverPlayer.awardStat(Stats.CUSTOM.get(StatInit.DISTANCE_CHARTED), (int) (totalDistance * 100));
                 
-                graph.createConnectedPath(this.chartedNodes);
+                List<Node> createdNodes = graph.createConnectedPath(this.chartedNodes);
+                for (Node node : createdNodes) {
+                    node.addVisitedPlayer(playerUUID);
+                }
+
                 PathDataManager.markDirty(serverLevel);
                 PathSyncUtils.syncPathGraphToAllPlayers(serverLevel);
                 awardChartingAdvancements(serverPlayer);

--- a/src/main/java/net/rasanovum/viaromana/network/packets/ConfigSyncS2C.java
+++ b/src/main/java/net/rasanovum/viaromana/network/packets/ConfigSyncS2C.java
@@ -10,7 +10,7 @@ import net.rasanovum.viaromana.network.AbstractPacket;
 /**
  * Server-to-client packet to synchronize server config values to the client.
  */
-public record ConfigSyncS2C(float pathQualityThreshold, int nodeDistanceMin, int nodeDistanceMax, int nodeUtilityDistance, int infrastructureCheckRadius) implements AbstractPacket {
+public record ConfigSyncS2C(float pathQualityThreshold, int nodeDistanceMin, int nodeDistanceMax, int nodeUtilityDistance, int infrastructureCheckRadius, boolean requireWalkedPath, int visitedNodeDecayTime) implements AbstractPacket {
 
     public ConfigSyncS2C(FriendlyByteBuf buf) {
         this(
@@ -18,6 +18,8 @@ public record ConfigSyncS2C(float pathQualityThreshold, int nodeDistanceMin, int
             buf.readInt(),
             buf.readInt(),
             buf.readInt(),
+            buf.readInt(),
+            buf.readBoolean(),
             buf.readInt()
         );
     }
@@ -28,16 +30,18 @@ public record ConfigSyncS2C(float pathQualityThreshold, int nodeDistanceMin, int
         buf.writeInt(this.nodeDistanceMax);
         buf.writeInt(this.nodeUtilityDistance);
         buf.writeInt(this.infrastructureCheckRadius);
+        buf.writeBoolean(this.requireWalkedPath);
+        buf.writeInt(this.visitedNodeDecayTime);
     }
 
     public void handle(Level level, Player player) {
         if (level.isClientSide) {
             ClientConfigCache.updateFromServer(
-                this.pathQualityThreshold, this.nodeDistanceMin, this.nodeDistanceMax, this.nodeUtilityDistance, this.infrastructureCheckRadius
+                this.pathQualityThreshold, this.nodeDistanceMin, this.nodeDistanceMax, this.nodeUtilityDistance, this.infrastructureCheckRadius, this.requireWalkedPath, this.visitedNodeDecayTime
             );
             
-            ViaRomana.LOGGER.debug("Received config sync from server: pathQuality={}, nodeMin={}, nodeMax={}, utility={}, infraRadius={}",
-                this.pathQualityThreshold, this.nodeDistanceMin, this.nodeDistanceMax, this.nodeUtilityDistance, this.infrastructureCheckRadius);
+            ViaRomana.LOGGER.debug("Received config sync from server: pathQuality={}, nodeMin={}, nodeMax={}, utility={}, infraRadius={}, requireWalked={}, decayTime={}",
+                this.pathQualityThreshold, this.nodeDistanceMin, this.nodeDistanceMax, this.nodeUtilityDistance, this.infrastructureCheckRadius, this.requireWalkedPath, this.visitedNodeDecayTime);
         }
     }
 }

--- a/src/main/java/net/rasanovum/viaromana/network/packets/DestinationRequestC2S.java
+++ b/src/main/java/net/rasanovum/viaromana/network/packets/DestinationRequestC2S.java
@@ -44,7 +44,7 @@ public record DestinationRequestC2S(BlockPos sourceSignPos) implements AbstractP
             PathGraph.NetworkCache cache = graph.getNetworkCache(sourceNode);
 
             List<DestinationResponseS2C.DestinationInfo> destInfos = graph.getNodesAsDestinationInfo(destinations, sourceNode.getBlockPos());
-            List<DestinationResponseS2C.NodeNetworkInfo> networkInfos = graph.getNodesAsInfo(cache);
+            List<DestinationResponseS2C.NodeNetworkInfo> networkInfos = graph.getNodesAsInfo(serverPlayer.getUUID(), cache);
 
             DestinationResponseS2C response = new DestinationResponseS2C(
                 destInfos,

--- a/src/main/java/net/rasanovum/viaromana/network/packets/DestinationResponseS2C.java
+++ b/src/main/java/net/rasanovum/viaromana/network/packets/DestinationResponseS2C.java
@@ -88,23 +88,27 @@ public record DestinationResponseS2C(
         public final BlockPos position;
         public final float clearance;
         public final List<BlockPos> connections;
+        public final boolean visited;
 
-        public NodeNetworkInfo(BlockPos position, float clearance, List<BlockPos> connections) {
+        public NodeNetworkInfo(BlockPos position, float clearance, List<BlockPos> connections, boolean visited) {
             this.position = position;
             this.clearance = clearance;
             this.connections = connections;
+            this.visited = visited;
         }
 
         public NodeNetworkInfo(FriendlyByteBuf buf) {
             this.position = buf.readBlockPos();
             this.clearance = buf.readFloat();
             this.connections = buf.readList(b -> b.readBlockPos());
+            this.visited = buf.readBoolean();
         }
 
         public void write(FriendlyByteBuf buf) {
             buf.writeBlockPos(position);
             buf.writeFloat(clearance);
             buf.writeCollection(connections, (b, pos) -> b.writeBlockPos(pos));
+            buf.writeBoolean(visited);
         }
     }
 }

--- a/src/main/java/net/rasanovum/viaromana/network/packets/NodeVisitedS2C.java
+++ b/src/main/java/net/rasanovum/viaromana/network/packets/NodeVisitedS2C.java
@@ -1,0 +1,44 @@
+package net.rasanovum.viaromana.network.packets;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.rasanovum.viaromana.client.data.ClientPathData;
+import net.rasanovum.viaromana.network.AbstractPacket;
+import net.rasanovum.viaromana.path.Node;
+import net.rasanovum.viaromana.path.PathGraph;
+import net.rasanovum.viaromana.util.VersionUtils;
+
+/**
+ * S2C Packet sent when a player visits a node to update the client-side visitation status.
+ */
+public record NodeVisitedS2C(BlockPos pos, long timestamp, ResourceKey<Level> dimension) implements AbstractPacket {
+
+    public NodeVisitedS2C(FriendlyByteBuf buf) {
+        this(
+            buf.readBlockPos(),
+            buf.readLong(),
+            ResourceKey.create(Registries.DIMENSION, VersionUtils.getLocation(buf.readUtf()))
+        );
+    }
+
+    public void write(FriendlyByteBuf buf) {
+        buf.writeBlockPos(this.pos);
+        buf.writeLong(this.timestamp);
+        buf.writeUtf(this.dimension.location().toString());
+    }
+
+    public void handle(Level level, Player player) {
+        if (level.isClientSide) {
+            PathGraph graph = ClientPathData.getInstance().getGraph(this.dimension);
+            if (graph != null) {
+                graph.getNodeAt(this.pos).ifPresent(node -> {
+                    node.addVisitedPlayerCustom(player.getUUID(), this.timestamp);
+                });
+            }
+        }
+    }
+}

--- a/src/main/java/net/rasanovum/viaromana/path/Node.java
+++ b/src/main/java/net/rasanovum/viaromana/path/Node.java
@@ -4,14 +4,23 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.Tag;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.LongPredicate;
+
+import net.rasanovum.viaromana.CommonConfig;
+import net.rasanovum.viaromana.client.ClientConfigCache;
 
 public class Node {
 
@@ -35,6 +44,7 @@ public class Node {
     private final float quality;
     private final int clearance;
     private final LongSet connectedNodes = new LongOpenHashSet();
+    private final Map<UUID, Long> visitedPlayers = new HashMap<>();
     private DestinationInfo destinationInfo = null; // Null if not a destination
     //endregion
 
@@ -82,6 +92,25 @@ public class Node {
             addConnection(c);
         }
 
+        if (tag.contains("visitedPlayers", Tag.TAG_LIST)) {
+            ListTag visitedList = tag.getList("visitedPlayers", Tag.TAG_COMPOUND);
+            if (!visitedList.isEmpty()) {
+                for (int i = 0; i < visitedList.size(); i++) {
+                    CompoundTag entry = visitedList.getCompound(i);
+                    if (entry.hasUUID("uuid")) {
+                        visitedPlayers.put(entry.getUUID("uuid"), entry.getLong("ts"));
+                    }
+                }
+            } else {
+                // Fallback for old format (List of UUIDs as IntArrays)
+                visitedList = tag.getList("visitedPlayers", Tag.TAG_INT_ARRAY);
+                long now = System.currentTimeMillis();
+                for (int i = 0; i < visitedList.size(); i++) {
+                    visitedPlayers.put(NbtUtils.loadUUID(visitedList.get(i)), now);
+                }
+            }
+        }
+
         if (tag.contains("destination", Tag.TAG_COMPOUND)) {
             CompoundTag destTag = tag.getCompound("destination");
             DestinationInfo dest = getOrCreateDestinationInfo();
@@ -104,6 +133,17 @@ public class Node {
         tag.putLong("pos", this.pos);
         tag.putByte("clearance", (byte) (this.clearance & 0xFF));
         tag.putLongArray("connections", this.connectedNodes.toLongArray());
+
+        if (!this.visitedPlayers.isEmpty()) {
+            ListTag visitedList = new ListTag();
+            for (Map.Entry<UUID, Long> entry : this.visitedPlayers.entrySet()) {
+                CompoundTag entryTag = new CompoundTag();
+                entryTag.putUUID("uuid", entry.getKey());
+                entryTag.putLong("ts", entry.getValue());
+                visitedList.add(entryTag);
+            }
+            tag.put("visitedPlayers", visitedList);
+        }
 
         if (this.destinationInfo != null) {
             CompoundTag destTag = new CompoundTag();
@@ -228,6 +268,40 @@ public class Node {
             case DESTINATION -> true;
             case PRIVATE -> Objects.equals(playerId, destinationInfo.privateOwner);
         };
+    }
+
+    public boolean addVisitedPlayer(UUID playerId) {
+        return addVisitedPlayerCustom(playerId, System.currentTimeMillis());
+    }
+
+    public boolean addVisitedPlayerCustom(UUID playerId, long timestamp) {
+        Long oldTs = visitedPlayers.put(playerId, timestamp);
+        
+        if (oldTs == null) return true;
+        
+        // If it was already visited, but it was decayed, we should mark as dirty to save the new visit
+        if (ClientConfigCache.visitedNodeDecayTime > 0) {
+            long decayMillis = (long) ClientConfigCache.visitedNodeDecayTime * 60 * 1000;
+            if (timestamp - oldTs > decayMillis) return true;
+        }
+
+        // Also mark as dirty if the timestamp is old enough that we want to refresh it on disk
+        // Refresh every 5 minutes if they are standing on it
+        return (timestamp - oldTs > 5 * 60 * 1000);
+    }
+
+    public boolean hasVisited(UUID playerId) {
+        Long timestamp = visitedPlayers.get(playerId);
+        if (timestamp == null) return false;
+        
+        if (ClientConfigCache.visitedNodeDecayTime <= 0) return true;
+        
+        long decayMillis = (long) ClientConfigCache.visitedNodeDecayTime * 60 * 1000;
+        return (System.currentTimeMillis() - timestamp) < decayMillis;
+    }
+
+    public Set<UUID> getVisitedPlayers() {
+        return Collections.unmodifiableSet(visitedPlayers.keySet());
     }
     //endregion
 

--- a/src/main/java/net/rasanovum/viaromana/path/Node.java
+++ b/src/main/java/net/rasanovum/viaromana/path/Node.java
@@ -275,19 +275,32 @@ public class Node {
     }
 
     public boolean addVisitedPlayerCustom(UUID playerId, long timestamp) {
-        Long oldTs = visitedPlayers.put(playerId, timestamp);
-        
-        if (oldTs == null) return true;
-        
-        // If it was already visited, but it was decayed, we should mark as dirty to save the new visit
-        if (ClientConfigCache.visitedNodeDecayTime > 0) {
-            long decayMillis = (long) ClientConfigCache.visitedNodeDecayTime * 60 * 1000;
-            if (timestamp - oldTs > decayMillis) return true;
+        Long oldTs = visitedPlayers.get(playerId);
+
+        if (oldTs == null) {
+            visitedPlayers.put(playerId, timestamp);
+            return true;
         }
 
-        // Also mark as dirty if the timestamp is old enough that we want to refresh it on disk
-        // Refresh every 5 minutes if they are standing on it
-        return (timestamp - oldTs > 5 * 60 * 1000);
+        long diff = timestamp - oldTs;
+
+        // Configuration-driven update interval
+        long decayMinutes = ClientConfigCache.visitedNodeDecayTime;
+        long updateIntervalMillis;
+
+        if (decayMinutes > 5 || decayMinutes <= 0) {
+            updateIntervalMillis = 5 * 60 * 1000; // Default to 5 minutes
+        } else {
+            // updates at half the decay time if decay is less than or equal to 5 minutes with a 30 second minimum duration
+            updateIntervalMillis = Math.max(30 * 1000, (decayMinutes * 60 * 1000) / 2);
+        }
+
+        if (diff > updateIntervalMillis) {
+            visitedPlayers.put(playerId, timestamp);
+            return true;
+        }
+
+        return false;
     }
 
     public boolean hasVisited(UUID playerId) {

--- a/src/main/java/net/rasanovum/viaromana/path/PathGraph.java
+++ b/src/main/java/net/rasanovum/viaromana/path/PathGraph.java
@@ -11,6 +11,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.ChunkPos;
 import net.rasanovum.viaromana.CommonConfig;
+import net.rasanovum.viaromana.client.ClientConfigCache;
 import net.rasanovum.viaromana.ViaRomana;
 import net.rasanovum.viaromana.map.ServerMapCache;
 import net.rasanovum.viaromana.map.ServerMapUtils;
@@ -61,21 +62,21 @@ public final class PathGraph {
             }
         }
 
-        public List<DestinationResponseS2C.NodeNetworkInfo> getNodesAsInfo(Long2IntOpenHashMap posToIndex, ObjectArrayList<Node> allNodes) {
+        public List<DestinationResponseS2C.NodeNetworkInfo> getNodesAsInfo(UUID playerId, Long2IntOpenHashMap posToIndex, ObjectArrayList<Node> nodes) {
             List<DestinationResponseS2C.NodeNetworkInfo> list = new ArrayList<>(nodePositions.size());
             LongIterator it = nodePositions.iterator();
             while (it.hasNext()) {
                 long pos = it.nextLong();
                 int index = posToIndex.getOrDefault(pos, -1);
                 if (index != -1) {
-                    Node node = allNodes.get(index);
+                    Node node = nodes.get(index);
                     List<BlockPos> connections = new ArrayList<>(node.getConnectedNodes().size());
                     for (long conn : node.getConnectedNodes()) {
                         connections.add(BlockPos.of(conn));
                     }
-                    list.add(new DestinationResponseS2C.NodeNetworkInfo(BlockPos.of(pos), node.getClearance(), connections));
+                    list.add(new DestinationResponseS2C.NodeNetworkInfo(BlockPos.of(pos), node.getClearance(), connections, node.hasVisited(playerId)));
                 } else {
-                    list.add(new DestinationResponseS2C.NodeNetworkInfo(BlockPos.of(pos), 0, Collections.emptyList()));
+                    list.add(new DestinationResponseS2C.NodeNetworkInfo(BlockPos.of(pos), 0, Collections.emptyList(), false));
                 }
             }
             return list;
@@ -231,8 +232,8 @@ public final class PathGraph {
         });
     }
 
-    public void createConnectedPath(List<Node.NodeData> pathData) {
-        if (pathData == null || pathData.size() < 2) return;
+    public List<Node> createConnectedPath(List<Node.NodeData> pathData) {
+        if (pathData == null || pathData.size() < 2) return List.of();
 
         List<Node> pathNodes = new ArrayList<>(pathData.size());
         for (Node.NodeData currentData : pathData) {
@@ -272,6 +273,8 @@ public final class PathGraph {
         for (Node node : pathNodes) {
             dirtyNodePositions.add(node.getPos());
         }
+
+        return pathNodes;
     }
 
     public void createOrUpdatePseudoNetwork(UUID pseudoNetworkId, List<Node.NodeData> tempNodes) {
@@ -542,6 +545,35 @@ public final class PathGraph {
         return Optional.ofNullable(bestNode);
     }
 
+    public boolean hasVisitedPath(UUID playerId, Node start, Node end) {
+        if (!ClientConfigCache.requireWalkedPath) return true;
+        if (start.getPos() == end.getPos()) return true;
+        if (!start.hasVisited(playerId) || !end.hasVisited(playerId)) return false;
+
+        Set<Long> visited = new HashSet<>();
+        Queue<Node> queue = new ArrayDeque<>();
+
+        visited.add(start.getPos());
+        queue.add(start);
+
+        while (!queue.isEmpty()) {
+            Node current = queue.poll();
+            if (current.getPos() == end.getPos()) return true;
+
+            for (long neighborPos : current.getConnectedNodes()) {
+                if (!visited.contains(neighborPos)) {
+                    getNodeAt(BlockPos.of(neighborPos)).ifPresent(neighbor -> {
+                        if (neighbor.hasVisited(playerId)) {
+                            visited.add(neighborPos);
+                            queue.add(neighbor);
+                        }
+                    });
+                }
+            }
+        }
+        return false;
+    }
+
     public List<Node> getNetwork(Node start) {
         List<Node> network = new ArrayList<>();
         LongOpenHashSet visited = new LongOpenHashSet();
@@ -595,6 +627,7 @@ public final class PathGraph {
         return cache.destinationNodes().stream()
                 .filter(node -> node.getPos() != sourceNode.getPos())
                 .filter(node -> node.isAccessibleBy(playerId))
+                .filter(node -> !ClientConfigCache.requireWalkedPath || hasVisitedPath(playerId, sourceNode, node))
                 .toList();
     }
 
@@ -800,8 +833,12 @@ public final class PathGraph {
     }
     //endregion
 
+    public List<DestinationResponseS2C.NodeNetworkInfo> getNodesAsInfo(UUID playerId, NetworkCache cache) {
+        return cache.getNodesAsInfo(playerId, posToIndex, nodes);
+    }
+
     public List<DestinationResponseS2C.NodeNetworkInfo> getNodesAsInfo(NetworkCache cache) {
-        return cache.getNodesAsInfo(this.posToIndex, this.nodes);
+        return cache.getNodesAsInfo(null, posToIndex, nodes);
     }
 
     public List<DestinationResponseS2C.DestinationInfo> getNodesAsDestinationInfo(List<net.rasanovum.viaromana.path.Node> nodes, BlockPos origin) {

--- a/src/main/java/net/rasanovum/viaromana/speed/SpeedHandler.java
+++ b/src/main/java/net/rasanovum/viaromana/speed/SpeedHandler.java
@@ -14,7 +14,11 @@ import net.rasanovum.viaromana.ViaRomana;
 import net.rasanovum.viaromana.init.StatInit;
 import net.rasanovum.viaromana.path.Node;
 import net.rasanovum.viaromana.path.PathGraph;
+import net.rasanovum.viaromana.storage.path.PathDataManager;
 import net.rasanovum.viaromana.util.VersionUtils;
+import net.rasanovum.viaromana.network.packets.NodeVisitedS2C;
+import net.rasanovum.viaromana.network.PacketRegistration;
+import dev.corgitaco.dataanchor.network.broadcast.PacketBroadcaster;
 //? if >=1.21 {
 import net.minecraft.advancements.AdvancementHolder;
 //?} else {
@@ -54,7 +58,14 @@ public class SpeedHandler {
 
         if (graph != null) {
             Optional<Node> nearestNode = graph.getNearestNode(player.blockPosition(), CommonConfig.node_distance_minimum);
-            nearNode = nearestNode.isPresent();
+            if (nearestNode.isPresent()) {
+                Node node = nearestNode.get();
+                if (node.addVisitedPlayer(player.getUUID())) {
+                    PathDataManager.markDirty((ServerLevel) player.level());
+                    PacketBroadcaster.S2C.sendToPlayer(new NodeVisitedS2C(node.getBlockPos(), System.currentTimeMillis(), player.level().dimension()), player);
+                }
+                nearNode = true;
+            }
         }
 
 //        net.rasanovum.viaromana.ViaRomana.LOGGER.info("Near Node: {}", nearNode);

--- a/src/main/java/net/rasanovum/viaromana/teleport/ServerTeleportHandler.java
+++ b/src/main/java/net/rasanovum/viaromana/teleport/ServerTeleportHandler.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -82,17 +83,30 @@ public class ServerTeleportHandler {
         ServerLevel level = player.serverLevel();
         PathGraph graph = PathGraph.getInstance(level);
 
-        graph.getNodeAt(packet.destinationPos()).ifPresent(targetNode -> {
-            activeTeleports.put(player.getUUID(), targetNode);
-            teleportStartTimes.put(player.getUUID(), level.getGameTime());
-            
-            PacketBroadcaster.S2C.sendToPlayer(new TeleportFadeS2C(
-                FADE_UP_TICKS,
-                HOLD_TICKS,
-                FADE_DOWN_TICKS,
-                FOOTSTEP_INTERVAL
-            ), player);
-        });
+        Optional<Node> targetNodeOpt = graph.getNodeAt(packet.destinationPos());
+        if (targetNodeOpt.isEmpty()) return;
+        Node targetNode = targetNodeOpt.get();
+
+        if (packet.originSignPos() != null) {
+            Optional<Node> originNodeOpt = graph.getNodeBySignPos(packet.originSignPos());
+            if (originNodeOpt.isPresent()) {
+                Node originNode = originNodeOpt.get();
+                if (!graph.hasVisitedPath(player.getUUID(), originNode, targetNode)) {
+                    player.displayClientMessage(Component.translatable("message.via_romana.path_not_walked"), true);
+                    return;
+                }
+            }
+        }
+
+        activeTeleports.put(player.getUUID(), targetNode);
+        teleportStartTimes.put(player.getUUID(), level.getGameTime());
+        
+        PacketBroadcaster.S2C.sendToPlayer(new TeleportFadeS2C(
+            FADE_UP_TICKS,
+            HOLD_TICKS,
+            FADE_DOWN_TICKS,
+            FOOTSTEP_INTERVAL
+        ), player);
     }
 
     private static void executeTeleportation(ServerPlayer player, Node targetNode) {

--- a/src/main/java/net/rasanovum/viaromana/util/PathSyncUtils.java
+++ b/src/main/java/net/rasanovum/viaromana/util/PathSyncUtils.java
@@ -79,7 +79,9 @@ public class PathSyncUtils {
                 CommonConfig.node_distance_minimum,
                 CommonConfig.node_distance_maximum,
                 CommonConfig.node_utility_distance,
-                CommonConfig.infrastructure_check_radius
+                CommonConfig.infrastructure_check_radius,
+                CommonConfig.require_walked_path,
+                CommonConfig.visited_node_decay_time
             );
             PacketBroadcaster.S2C.sendToPlayer(packet, player);
             
@@ -99,7 +101,9 @@ public class PathSyncUtils {
                 CommonConfig.node_distance_minimum,
                 CommonConfig.node_distance_maximum,
                 CommonConfig.node_utility_distance,
-                CommonConfig.infrastructure_check_radius
+                CommonConfig.infrastructure_check_radius,
+                CommonConfig.require_walked_path,
+                CommonConfig.visited_node_decay_time
             );
 
             for (ServerPlayer player : server.getPlayerList().getPlayers()) {

--- a/src/main/resources/assets/via_romana/lang/en_us.json
+++ b/src/main/resources/assets/via_romana/lang/en_us.json
@@ -26,6 +26,7 @@
   "message.via_romana.cannot_warp_when_recording": "Cannot warp while charting",
   "message.via_romana.entity_not_allowed": "Warping with current entity not allowed",
   "message.via_romana.unsafe": "Cannot warp to an unsafe destination",
+  "message.via_romana.path_not_walked": "You haven't walked this entire path yet",
 
   "gui.viaromana.left_click_hover_tip": "Left-click to open Travel Map",
 
@@ -124,6 +125,12 @@
   "via_romana.midnightconfig.node_distance_maximum.tooltip": "The maximum distance (in blocks) between two nodes.\n • Server Managed",
   "via_romana.midnightconfig.node_utility_distance": "Node Utility Distance",
   "via_romana.midnightconfig.node_utility_distance.tooltip": "The distance (in blocks) to select the nearest node from for actions like connect, sever, and delete.\n • Server Managed",
+  "via_romana.midnightconfig.visited_node_decay_time": "Visited Node Decay Time",
+  "via_romana.midnightconfig.visited_node_decay_time.tooltip": "The time (in minutes) after which a visited node is forgotten by the player (0 = no decay).\n • Server Managed",
+  "via_romana.midnightconfig.require_walked_path": "Require Walked Path",
+  "via_romana.midnightconfig.require_walked_path.tooltip": "When enabled, players must physically walk along a charted path before they can use warp signs along it.\n • Server Managed",
+  "via_romana.midnightconfig.visited_line_color": "Visited Path Color",
+  "via_romana.midnightconfig.visited_line_color.tooltip": "The color of the path on the map for nodes the player has visited.\n • Client Managed",
   "via_romana.midnightconfig.path_quality_threshold": "Path Quality Threshold",
   "via_romana.midnightconfig.path_quality_threshold.tooltip": "Minimum percentage of valid infrastructure blocks required to place a node (eg. 0.3 = 30%% of a 2D slice of area check).\n • Server Managed",
   "via_romana.midnightconfig.travel_fatigue_cooldown": "Travel Fatigue Cooldown",


### PR DESCRIPTION
* Nodes now track `PlayerUUID -> Timestamp` in a Map. Added decay logic so a player can optionally be required to traverse the path again. Essentially, this works by saving a timestamp together with the player name into the node. Amount of time before node becomes "un-visited" can be configured in minutes.
* You can’t warp between signs unless you’ve physically walked the path nodes in between. If you charted the path yourself, you get added to all the nodes along the path you just made, together with a timestamp, so you do not need to re-walk the whole path. Decay applies as usual.
* Built a `ClientConfigCache` so the client respects server-side rules (decay, toggles) without constant polling. Added packets to sync visits in real-time.
* **Visuals**: Map lines and in-world beams now highlight based on visitation status. Uses a hex-configurable color (default blue).
* **NeoForge Fixes**: Had to patch the map baker and constructor mismatches in 1.21.1 because the new visitation flags broke the old build.
* New config options to enable and disable the above.

This addresses https://github.com/RasaNovum/Via_Romana/issues/42

Screenshots:

Visited and unvisited nodes:
<img width="1483" height="698" alt="image" src="https://github.com/user-attachments/assets/b6b1ef2b-129b-4163-8983-652cdfd2e60b" />

Color configurable:
<img width="2499" height="1024" alt="image" src="https://github.com/user-attachments/assets/e74edd06-26ac-4bb9-83c5-5816b19e12c2" />

Walked path indicator:
<img width="1243" height="1060" alt="image" src="https://github.com/user-attachments/assets/d671a48c-e6eb-4008-ac48-7d946edf6e10" />

Signs only show up on fully walked, non decayed paths:
<img width="1337" height="1332" alt="image" src="https://github.com/user-attachments/assets/46c51e7d-1197-45be-b445-45a756ffed94" />
