### PR TITLE
Allow newer Data Anchor versions instead of pinning to one exact build

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -43,6 +43,6 @@ side = "BOTH"
 [[dependencies.${modId}]]
 modId = "dataanchor"
 mandatory = true
-versionRange = "[${dataanchor}]"
+versionRange = "[${dataanchor},)"
 ordering = "NONE"
 side = "BOTH"

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -46,6 +46,6 @@ side = "BOTH"
 [[dependencies.${modId}]]
 modId = "dataanchor"
 type = "required"
-versionRange = "[${dataanchor}]"
+versionRange = "[${dataanchor},)"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
### Problem

`mods.toml` (and `neoforge.mods.toml`) declare the Data Anchor dependency as:

```toml
versionRange = "[${dataanchor}]"
```

Maven reads `[x]` as *exactly* `x`, so Data Anchor cannot be updated at all — Forge stops the server with:

```
Mod ID: 'dataanchor', Requested by: 'via_romana',
Expected range: '[1.0.0.20,1.0.0.20]', Actual version: '1.0.0.22'
```

This is blocking right now because Data Anchor **1.0.0.22** ships *"Fix 1.20.1 crashes by making packet registry static"* — a 1.20.1-specific crash fix that packs on 1.20.1 cannot pick up while the pin is in place.

### Change

`[${dataanchor}]` → `[${dataanchor},)` in both toml files. The property itself is untouched, so the minimum stays whatever `deps.data-anchor` says.

### Why this is safe (checked, not assumed)

I extracted every Data Anchor member referenced from the constant pool of `via_romana-2.2.2+1.20.1-forge.jar` — **15 call sites**:

- `TrackedDataRegistries.ENTITY` / `.LEVEL`
- `TrackedDataRegistry#register` / `#getContainer`
- `TrackedDataContainer#dataAnchor$createTrackedData` / `#dataAnchor$getTrackedData`
- `TrackedDataKey#getId`
- `SyncedPlayerTrackedData#<init>` / `#sync`
- `ServerLevelTrackedData#<init>` / `#markDirty`
- `C2SNetworkContainer#of`, `S2CNetworkContainer#of`, `NetworkContainer#registerPacketHandler`
- `Packet$Handler#<init>`, `PacketBroadcaster.C2S` / `.S2C`, `C2SPacketBroadcaster#sendToServer`, `S2CPacketBroadcaster#sendToPlayer`

and resolved each against **both 1.0.0.20 and 1.0.0.22**, following superclasses and interfaces:

| version | missing classes | missing methods |
| - | - | - |
| 1.0.0.20 | 0 | 0 |
| 1.0.0.22 | 0 | 0 |

Descriptors match exactly, so no `NoSuchMethodError` from the bump.

### Caveat

1.0.0.21 reworked packet registration ("Networking backend improvements. Minimize Packet registration boilerplate."), so behaviour depending on registration *order or lifetime* could still differ — that is not something the signature check can rule out.

What I have actually run: a 1.20.1 Forge server with ~280 mods on Data Anchor 1.0.0.22 with this change applied. It boots cleanly and completes the client handshake. I have not exercised every Via Romana path, so if you would rather use a bounded range such as `[${dataanchor},1.0.1)` that works for us too.